### PR TITLE
chore: upgrade Android/Gradle toolchain

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.7.3")
+        classpath("com.android.tools.build:gradle:8.11.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -50,7 +50,5 @@ android {
     dependencies {
         implementation("com.wireguard.android:tunnel:1.0.20250531")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-       // uncomment this for access to the Flutter API in IDE for syntax highlighting of Flutter classes
-       // implementation files('libs/flutter.jar')
     }
 } 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group = "dev.fluttercommunity.flutter_wireguard"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.8.22"
+    ext.kotlin_version = "2.2.21"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("com.android.tools.build:gradle:8.7.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "dev.fluttercommunity.flutter_wireguard"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -49,7 +49,7 @@ android {
 
     dependencies {
         implementation("com.wireguard.android:tunnel:1.0.20250531")
-        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
        // uncomment this for access to the Flutter API in IDE for syntax highlighting of Flutter classes
        // implementation files('libs/flutter.jar')
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group = "dev.fluttercommunity.flutter_wireguard"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "2.2.21"
+    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -30,12 +30,12 @@ android {
     compileSdk = 36
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 25
+        minSdk = 26
     }
 
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,4 +53,4 @@ android {
        // uncomment this for access to the Flutter API in IDE for syntax highlighting of Flutter classes
        // implementation files('libs/flutter.jar')
     }
-}
+} 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,4 +51,4 @@ android {
         implementation("com.wireguard.android:tunnel:1.0.20250531")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     }
-} 
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,1 @@
 android.useAndroidX=true
-android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,2 @@
 android.useAndroidX=true
-
-
+android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,3 @@
+android.useAndroidX=true
+
+

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_wireguard
 description: Flutter plugin for Wireguard
 version: 0.0.1
-homepage:
+homepage: https://github.com/pedramktb/flutter-wireguard
 
 environment:
   sdk: ^3.1.0


### PR DESCRIPTION
Upgrades the Android build toolchain to modern versions:

- Bump `minSdk` to a higher version
- Upgrade Java to 17
- Upgrade Android Gradle Plugin
- Update Gradle wrapper to 8.13
- Clean up `gradle.properties`

No Dart or plugin logic changes — build infrastructure only.