### PR TITLE
feat(android): separate process for Go runtime via AIDL

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,10 @@ android {
         jvmTarget = JavaVersion.VERSION_11
     }
 
+    buildFeatures {
+        aidl = true
+    }
+
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
         test.java.srcDirs += "src/test/kotlin"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,30 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="dev.fluttercommunity.flutter_wireguard">
+
+  <application>
+
+    <!--
+      WireguardService owns GoBackend and libwg-go.so.
+      Declaring it in android:process=":wireguard" keeps the wireguard-go runtime
+      (Go 1.23.x) in a separate address space from other potentially Go-using libraries
+      in the main Flutter process, preventing the dual-Go-runtime crash.
+    -->
+    <service
+      android:name=".WireguardService"
+      android:process=":wireguard"
+      android:exported="false" />
+
+    <!--
+      GoBackend internally starts GoBackend$VpnService to establish the VPN socket.
+      Override the process attribute so it also starts in ':wireguard', ensuring
+      libwg-go.so is never mapped into the main process.
+    -->
+    <service
+      android:name="com.wireguard.android.backend.GoBackend$VpnService"
+      android:process=":wireguard"
+      tools:node="merge" />
+
+  </application>
+
 </manifest>

--- a/android/src/main/aidl/dev/fluttercommunity/flutter_wireguard/IWireguard.aidl
+++ b/android/src/main/aidl/dev/fluttercommunity/flutter_wireguard/IWireguard.aidl
@@ -1,0 +1,21 @@
+package dev.fluttercommunity.flutter_wireguard;
+
+import dev.fluttercommunity.flutter_wireguard.IWireguardCallback;
+
+// Binder interface exposed by WireguardService running in the :wireguard process.
+interface IWireguard {
+    // Start/stop a named tunnel. Blocking until the backend state change completes.
+    void start(String name, String config);
+    void stop(String name);
+
+    // Returns current tunnel status as a JSON string, or null if the tunnel does not exist.
+    String statusJson(String name);
+
+    // Returns the active backend: "GoBackend" or "WgQuickBackend (kernel)".
+    String backendType();
+
+    // Register/unregister a callback for live status updates.
+    // oneway = fire-and-forget; never blocks the calling thread (main thread safe).
+    oneway void registerCallback(IWireguardCallback callback);
+    oneway void unregisterCallback(IWireguardCallback callback);
+}

--- a/android/src/main/aidl/dev/fluttercommunity/flutter_wireguard/IWireguardCallback.aidl
+++ b/android/src/main/aidl/dev/fluttercommunity/flutter_wireguard/IWireguardCallback.aidl
@@ -1,0 +1,7 @@
+package dev.fluttercommunity.flutter_wireguard;
+
+// Callbacks delivered from the :wireguard process to the main process.
+// oneway = non-blocking fire-and-forget (caller never waits for return).
+oneway interface IWireguardCallback {
+    void onTunnelStatus(String name, String state, long rx, long tx, long handshake);
+}

--- a/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/FlutterWireguardPlugin.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/FlutterWireguardPlugin.kt
@@ -1,10 +1,14 @@
 package dev.fluttercommunity.flutter_wireguard
 
 import android.app.Activity
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import com.wireguard.android.backend.GoBackend
-import com.wireguard.android.backend.BackendException
+import android.content.ServiceConnection
+import android.net.VpnService
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -17,131 +21,234 @@ import io.flutter.plugin.common.PluginRegistry.ActivityResultListener
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import org.json.JSONObject
 
 private const val permissionRequestCode = 10014
 
+/**
+ * Runs in the MAIN process alongside Flutter
+ *
+ * It never imports GoBackend and never calls System.loadLibrary("wg-go"), so
+ * the wireguard-go runtime stays isolated in the ':wireguard' process where
+ * WireguardService lives.
+ *
+ * VPN permission is requested here because it needs a foreground Activity.
+ * android.net.VpnService.prepare() (the base class) is used — it does not load
+ * any WireGuard native library.
+ */
 class FlutterWireguardPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, ActivityResultListener {
+
     private lateinit var methodChannel: MethodChannel
     private lateinit var eventChannel: EventChannel
-    private lateinit var wireguard: Wireguard
-    private var activity: Activity? = null
-    private var permission: Boolean = false
-    private var eventSink: EventChannel.EventSink? = null
-    private val scope = CoroutineScope(Dispatchers.IO)
 
-    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        methodChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "dev.fluttercommunity.flutter_wireguard/methodChannel")
+    private var appContext: Context? = null
+    private var activity: Activity? = null
+    private var eventSink: EventChannel.EventSink? = null
+
+    // Background scope for blocking cross-process AIDL calls.
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    // EventSink must be touched on the main thread.
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    // Binder proxy to WireguardService running in ':wireguard' process.
+    @Volatile private var wireguardService: IWireguard? = null
+
+    // ------------------------------------------------------------------
+    // Service connection
+    // ------------------------------------------------------------------
+
+    private val serviceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName, binder: IBinder) {
+            wireguardService = IWireguard.Stub.asInterface(binder)
+            wireguardService?.registerCallback(wireguardCallback)
+        }
+
+        override fun onServiceDisconnected(name: ComponentName) {
+            // Remote ':wireguard' process was killed; attempt to rebind.
+            wireguardService = null
+            appContext?.let { bindWireguardService(it) }
+        }
+    }
+
+    // Receives live status events from WireguardService (called on a Binder thread).
+    private val wireguardCallback = object : IWireguardCallback.Stub() {
+        override fun onTunnelStatus(
+            name: String, state: String, rx: Long, tx: Long, handshake: Long
+        ) {
+            mainHandler.post {
+                eventSink?.success(
+                    mapOf(
+                        "name" to name,
+                        "state" to state,
+                        "rx" to rx,
+                        "tx" to tx,
+                        "handshake" to handshake
+                    )
+                )
+            }
+        }
+    }
+
+    private fun bindWireguardService(ctx: Context) {
+        val intent = Intent(ctx, WireguardService::class.java)
+        ctx.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
+    }
+
+    // ------------------------------------------------------------------
+    // FlutterPlugin
+    // ------------------------------------------------------------------
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        appContext = binding.applicationContext
+
+        methodChannel = MethodChannel(
+            binding.binaryMessenger,
+            "dev.fluttercommunity.flutter_wireguard/methodChannel"
+        )
         methodChannel.setMethodCallHandler(this)
-        eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, "dev.fluttercommunity.flutter_wireguard/eventChannel")
-        wireguard = Wireguard.getInstance(flutterPluginBinding.applicationContext)
+
+        eventChannel = EventChannel(
+            binding.binaryMessenger,
+            "dev.fluttercommunity.flutter_wireguard/eventChannel"
+        )
         eventChannel.setStreamHandler(object : EventChannel.StreamHandler {
             override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
                 eventSink = events
-                scope.launch {
-                    wireguard.tunnelStatusFlow.collect { tunnelStatuses ->
-                        tunnelStatuses.forEach { (name, status) ->
-                            withContext(Dispatchers.Main) {
-                                eventSink?.success(mapOf(
-                                        "name" to name,
-                                        "state" to status.state.toString(),
-                                        "rx" to status.rx,
-                                        "tx" to status.tx,
-                                        "handshake" to status.handshake
-                                ))
-                            }
-                        }
-                    }
-                }
             }
-
             override fun onCancel(arguments: Any?) {
                 eventSink = null
             }
         })
+
+        bindWireguardService(binding.applicationContext)
     }
 
-    override fun onDetachedFromEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        scope.cancel(CancellationException("Plugin detached"))
-        eventSink = null
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        try { wireguardService?.unregisterCallback(wireguardCallback) } catch (_: Exception) {}
+        try { appContext?.unbindService(serviceConnection) } catch (_: Exception) {}
+
+        wireguardService = null
+        appContext = null
+
         methodChannel.setMethodCallHandler(null)
         eventChannel.setStreamHandler(null)
+        scope.cancel(CancellationException("Plugin detached"))
     }
 
+    // ------------------------------------------------------------------
+    // MethodCallHandler
+    // ------------------------------------------------------------------
+
     override fun onMethodCall(call: MethodCall, result: Result) {
+        val svc = wireguardService
+        if (svc == null) {
+            result.error("NOT_CONNECTED", "WireguardService not yet bound", null)
+            return
+        }
+
         when (call.method) {
             "start" -> {
+                val name: String = call.argument("name")!!
+                val config: String = call.argument("config")!!
+                // AIDL start() blocks until GoBackend state change completes — run on IO.
                 scope.launch {
-                    wireguard.start(call.argument("name")!!, call.argument("config")!!)
-                    result.success(null)
+                    try {
+                        svc.start(name, config)
+                        mainHandler.post { result.success(null) }
+                    } catch (e: Exception) {
+                        mainHandler.post { result.error("START_FAILED", e.message, null) }
+                    }
                 }
             }
+
             "stop" -> {
-
+                val name: String = call.argument("name")!!
                 scope.launch {
-                    wireguard.stop(call.argument("name")!!)
-                    result.success(null)
-
+                    try {
+                        svc.stop(name)
+                        mainHandler.post { result.success(null) }
+                    } catch (e: Exception) {
+                        mainHandler.post { result.error("STOP_FAILED", e.message, null) }
+                    }
                 }
             }
+
             "status" -> {
+                val name: String = call.argument("name")!!
                 scope.launch {
-                    val status = wireguard.status(call.argument("name")!!)
-                    result.success(mapOf(
-                            "name" to status.name,
-                            "state" to status.state.toString(),
-                            "rx" to status.rx,
-                            "tx" to status.tx,
-                            "handshake" to status.handshake
-                    ))
+                    try {
+                        val json = svc.statusJson(name)
+                        if (json == null) {
+                            mainHandler.post {
+                                result.error("NO_STATUS", "Tunnel '$name' not found", null)
+                            }
+                            return@launch
+                        }
+                        val obj = JSONObject(json)
+                        val map = mapOf(
+                            "name" to obj.getString("name"),
+                            "state" to obj.getString("state"),
+                            "rx" to obj.getLong("rx"),
+                            "tx" to obj.getLong("tx"),
+                            "handshake" to obj.getLong("handshake")
+                        )
+                        mainHandler.post { result.success(map) }
+                    } catch (e: Exception) {
+                        mainHandler.post { result.error("STATUS_FAILED", e.message, null) }
+                    }
                 }
             }
+
+            "backendType" -> {
+                scope.launch {
+                    try {
+                        val type = svc.backendType()
+                        mainHandler.post { result.success(type) }
+                    } catch (e: Exception) {
+                        mainHandler.post { result.error("BACKEND_TYPE_FAILED", e.message, null) }
+                    }
+                }
+            }
+
             else -> result.notImplemented()
         }
     }
 
-    override fun onAttachedToActivity(activityPluginBinding: ActivityPluginBinding) {
-        activity = activityPluginBinding.activity
-        getPermission()
+    // ------------------------------------------------------------------
+    // ActivityAware — VPN permission (no GoBackend involved)
+    // ------------------------------------------------------------------
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activity = binding.activity
+        binding.addActivityResultListener(this)
+        requestVpnPermission()
     }
 
-    override fun onDetachedFromActivity() {
-        activity = null
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        activity = binding.activity
+        binding.addActivityResultListener(this)
+        requestVpnPermission()
     }
 
-    override fun onReattachedToActivityForConfigChanges(activityPluginBinding: ActivityPluginBinding) {
-        activity = activityPluginBinding.activity
-        getPermission()
-    }
+    override fun onDetachedFromActivity() { activity = null }
+    override fun onDetachedFromActivityForConfigChanges() { activity = null }
 
-    override fun onDetachedFromActivityForConfigChanges() {
-        activity = null
-    }
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean =
+        requestCode == permissionRequestCode && resultCode == Activity.RESULT_OK
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-        permission = (requestCode == permissionRequestCode) && (resultCode == Activity.RESULT_OK)
-        return permission
-    }
-
-    private fun getPermission() {
-        if (permission) {
-            return
-        }
-
-        val intent = if (wireguard.wgQuickBackend()) {
-            null
-        } else if (wireguard.goBackend()) {
-            GoBackend.VpnService.prepare(activity)
-        } else {
-            throw Exception("No backend available")
-        }
-
+    /**
+     * Request VPN permission using the base android.net.VpnService — not GoBackend.VpnService.
+     * This does NOT import or instantiate GoBackend so libwg-go.so is never mapped in the
+     * main process.
+     */
+    private fun requestVpnPermission() {
+        val act = activity ?: return
+        val intent = VpnService.prepare(act)
         if (intent != null) {
-            activity?.startActivityForResult(intent, permissionRequestCode)
-        } else {
-            permission = true;
+            act.startActivityForResult(intent, permissionRequestCode)
         }
     }
 }

--- a/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/FlutterWireguardPlugin.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/FlutterWireguardPlugin.kt
@@ -56,20 +56,35 @@ class FlutterWireguardPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, 
     // Binder proxy to WireguardService running in ':wireguard' process.
     @Volatile private var wireguardService: IWireguard? = null
 
+    // Guard against rebinding during teardown (onDetachedFromEngine).
+    @Volatile private var isEngineAttached = false
+
+    // Stored binding reference for removing the ActivityResultListener on detach.
+    private var activityBinding: ActivityPluginBinding? = null
+
     // ------------------------------------------------------------------
     // Service connection
     // ------------------------------------------------------------------
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName, binder: IBinder) {
-            wireguardService = IWireguard.Stub.asInterface(binder)
-            wireguardService?.registerCallback(wireguardCallback)
+            val svc = IWireguard.Stub.asInterface(binder)
+            try {
+                svc.registerCallback(wireguardCallback)
+                wireguardService = svc
+            } catch (_: Exception) {
+                // Binder failure during registration; clear and retry.
+                wireguardService = null
+                appContext?.let { bindWireguardService(it) }
+            }
         }
 
         override fun onServiceDisconnected(name: ComponentName) {
-            // Remote ':wireguard' process was killed; attempt to rebind.
+            // Remote ':wireguard' process was killed; attempt to rebind only if still attached.
             wireguardService = null
-            appContext?.let { bindWireguardService(it) }
+            if (isEngineAttached) {
+                appContext?.let { bindWireguardService(it) }
+            }
         }
     }
 
@@ -102,6 +117,7 @@ class FlutterWireguardPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, 
     // ------------------------------------------------------------------
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        isEngineAttached = true
         appContext = binding.applicationContext
 
         methodChannel = MethodChannel(
@@ -127,6 +143,9 @@ class FlutterWireguardPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, 
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        // Mark as detached before unbind to prevent onServiceDisconnected from rebinding.
+        isEngineAttached = false
+        eventSink = null
         try { wireguardService?.unregisterCallback(wireguardCallback) } catch (_: Exception) {}
         try { appContext?.unbindService(serviceConnection) } catch (_: Exception) {}
 
@@ -180,14 +199,7 @@ class FlutterWireguardPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, 
                 val name: String = call.argument("name")!!
                 scope.launch {
                     try {
-                        val json = svc.statusJson(name)
-                        if (json == null) {
-                            mainHandler.post {
-                                result.error("NO_STATUS", "Tunnel '$name' not found", null)
-                            }
-                            return@launch
-                        }
-                        val obj = JSONObject(json)
+                        val obj = JSONObject(svc.statusJson(name))
                         val map = mapOf(
                             "name" to obj.getString("name"),
                             "state" to obj.getString("state"),
@@ -222,22 +234,36 @@ class FlutterWireguardPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, 
     // ------------------------------------------------------------------
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activityBinding = binding
         activity = binding.activity
         binding.addActivityResultListener(this)
         requestVpnPermission()
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        activityBinding = binding
         activity = binding.activity
         binding.addActivityResultListener(this)
         requestVpnPermission()
     }
 
-    override fun onDetachedFromActivity() { activity = null }
-    override fun onDetachedFromActivityForConfigChanges() { activity = null }
+    override fun onDetachedFromActivity() {
+        activityBinding?.removeActivityResultListener(this)
+        activityBinding = null
+        activity = null
+    }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean =
-        requestCode == permissionRequestCode && resultCode == Activity.RESULT_OK
+    override fun onDetachedFromActivityForConfigChanges() {
+        activityBinding?.removeActivityResultListener(this)
+        activityBinding = null
+        activity = null
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode != permissionRequestCode) return false
+        // Always consume the VPN permission result (granted or denied).
+        return true
+    }
 
     /**
      * Request VPN permission using the base android.net.VpnService — not GoBackend.VpnService.

--- a/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/Wireguard.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/Wireguard.kt
@@ -57,6 +57,7 @@ class Wireguard private constructor(context: Context) {
 
     fun goBackend() : Boolean = backend is GoBackend
     fun wgQuickBackend() : Boolean = backend is WgQuickBackend
+    fun backendType(): String = if (backend is GoBackend) "GoBackend" else "WgQuickBackend (kernel)"
 
     fun start(name: String, config:String) {
         Log.i("WireGuard", "Starting tunnel: $name")

--- a/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/WireguardService.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/WireguardService.kt
@@ -1,0 +1,113 @@
+package dev.fluttercommunity.flutter_wireguard
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.os.RemoteCallbackList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+
+/**
+ * Runs in the ':wireguard' process (declared in AndroidManifest.xml).
+ *
+ * This isolates libwg-go.so (wireguard-go, embedded inside com.wireguard.android:tunnel)
+ * from libnetxlib.so in the main process.  Two Go runtimes built with different Go versions
+ * cannot safely coexist in the same process address space, because each embeds its own
+ * signal handlers, goroutine scheduler, and GC root tables.
+ *
+ * All WireGuard work (GoBackend, tunnels, VPN socket) stays in this process.
+ * The main Flutter process communicates via the IWireguard AIDL binder and receives
+ * live status updates through IWireguardCallback (oneway, non-blocking).
+ */
+class WireguardService : Service() {
+
+    private lateinit var wireguard: Wireguard
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    // Thread-safe list of remotely registered callbacks (main-process binder proxies).
+    private val callbacks = RemoteCallbackList<IWireguardCallback>()
+
+    // ------------------------------------------------------------------
+    // AIDL binder implementation
+    // ------------------------------------------------------------------
+
+    private val binder = object : IWireguard.Stub() {
+
+        override fun start(name: String, config: String) {
+            wireguard.start(name, config)
+        }
+
+        override fun stop(name: String) {
+            wireguard.stop(name)
+        }
+
+        override fun statusJson(name: String): String? {
+            return try {
+                val s = wireguard.status(name)
+                JSONObject().apply {
+                    put("name", s.name)
+                    put("state", s.state.toString())
+                    put("rx", s.rx)
+                    put("tx", s.tx)
+                    put("handshake", s.handshake)
+                }.toString()
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        override fun backendType(): String = wireguard.backendType()
+
+        override fun registerCallback(callback: IWireguardCallback) {
+            callbacks.register(callback)
+        }
+
+        override fun unregisterCallback(callback: IWireguardCallback) {
+            callbacks.unregister(callback)
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Lifecycle
+    // ------------------------------------------------------------------
+
+    override fun onCreate() {
+        super.onCreate()
+        wireguard = Wireguard.getInstance(applicationContext)
+
+        // Forward tunnel status changes to all registered remote callbacks.
+        scope.launch {
+            wireguard.tunnelStatusFlow.collect { statuses ->
+                statuses.forEach { (name, status) ->
+                    val count = callbacks.beginBroadcast()
+                    for (i in 0 until count) {
+                        try {
+                            callbacks.getBroadcastItem(i).onTunnelStatus(
+                                name,
+                                status.state.toString(),
+                                status.rx,
+                                status.tx,
+                                status.handshake
+                            )
+                        } catch (_: Exception) {
+                            // Dead callback; RemoteCallbackList removes it automatically.
+                        }
+                    }
+                    callbacks.finishBroadcast()
+                }
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder = binder
+
+    override fun onDestroy() {
+        scope.cancel()
+        callbacks.kill()
+        super.onDestroy()
+    }
+}

--- a/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/WireguardService.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/flutter_wireguard/WireguardService.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
@@ -46,18 +47,16 @@ class WireguardService : Service() {
         }
 
         override fun statusJson(name: String): String? {
-            return try {
-                val s = wireguard.status(name)
-                JSONObject().apply {
-                    put("name", s.name)
-                    put("state", s.state.toString())
-                    put("rx", s.rx)
-                    put("tx", s.tx)
-                    put("handshake", s.handshake)
-                }.toString()
-            } catch (_: Exception) {
-                null
-            }
+            // Let exceptions propagate over Binder so the caller can distinguish
+            // backend failures from a tunnel-not-found null return.
+            val s = wireguard.status(name)
+            return JSONObject().apply {
+                put("name", s.name)
+                put("state", s.state.toString())
+                put("rx", s.rx)
+                put("tx", s.tx)
+                put("handshake", s.handshake)
+            }.toString()
         }
 
         override fun backendType(): String = wireguard.backendType()

--- a/lib/flutter_wireguard.dart
+++ b/lib/flutter_wireguard.dart
@@ -17,4 +17,8 @@ class FlutterWireguard extends FlutterWireguardPlatformInterface {
   @override
   Stream<Map<String, dynamic>> statusStream() =>
       FlutterWireguardPlatformInterface.instance.statusStream();
+
+  @override
+  Future<String> backendType() =>
+      FlutterWireguardPlatformInterface.instance.backendType();
 }

--- a/lib/flutter_wireguard_method_channel.dart
+++ b/lib/flutter_wireguard_method_channel.dart
@@ -48,6 +48,10 @@ class FlutterWireguardMethodChannel extends FlutterWireguardPlatformInterface {
           : throw invalidStatus);
 
   @override
+  Future<String> backendType() async =>
+      await _methodChannel.invokeMethod<String>('backendType') ?? 'unknown';
+
+  @override
   Stream<Map<String, dynamic>> statusStream() =>
       _eventChannel.receiveBroadcastStream().map((event) => event is Map
           ? {

--- a/lib/flutter_wireguard_platform_interface.dart
+++ b/lib/flutter_wireguard_platform_interface.dart
@@ -26,4 +26,6 @@ abstract class FlutterWireguardPlatformInterface extends PlatformInterface {
       throw UnimplementedError();
 
   Stream<Map<String, dynamic>> statusStream() => throw UnimplementedError();
+
+  Future<String> backendType() => throw UnimplementedError();
 }


### PR DESCRIPTION
Moves the WireGuard Go runtime into a dedicated Android service process using AIDL, improving stability and lifecycle management.

**Changes:**
- Add `IWireguard.aidl` and `IWireguardCallback.aidl` interface definitions
- Introduce `WireguardService.kt` as a bound service running in its own process
- Refactor `FlutterWireguardPlugin.kt` to bind/unbind to the service and proxy calls over AIDL
- Update `AndroidManifest.xml` to declare the service with `android:process`
- Expose new method(s) in the Dart platform interface and method channel
- Minor `build.gradle` update for AIDL support

**Note:** This branch has a small conflict on `android/build.gradle` with `upgrade_dart` — merge that PR first to resolve cleanly.